### PR TITLE
Use unsafe conversion from Chunk to SdkBytes to avoid data copying

### DIFF
--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/GeneratorBase.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/GeneratorBase.scala
@@ -56,7 +56,7 @@ trait GeneratorBase {
           ZIO.succeed(q"""$term.unwrap""")
         }
       case ModelType.Blob =>
-        ZIO.succeed(q"""SdkBytes.fromByteArray($term.toArray[Byte])""")
+        ZIO.succeed(q"""SdkBytes.fromByteArrayUnsafe($term.toArray[Byte])""")
       case ModelType.Structure =>
         ZIO.succeed(q"""$term.buildAwsValue()""")
       case ModelType.Exception =>


### PR DESCRIPTION
This should be fine with the immutability characteristics of Chunk and SdkBytes